### PR TITLE
DONTMERGE: fix(scummtr): Work around script bug in 07.LFL in MANIAC-V2-EN

### DIFF
--- a/src/ScummTr/script.cpp
+++ b/src/ScummTr/script.cpp
@@ -1560,6 +1560,23 @@ void Script::_opv12()
 		_eatWordOrVar(opcode & 0x80);
 		break;
 	case 0x62: // stopScript
+		// Some versions of MANIAC-V2 miss a call to printEgo (0xD8) after calling
+		// stopScript in 07.LFL. Since interpreters will ignore this string anyway,
+		// ignore it here too.
+		if (ScummRp::game.version == 2 && ScummRp::game.id == GID_MANIAC && _file->name().rfind("07.LFL", 0) == 0)
+		{
+			byte b;
+			b = _eatByteOrVar(opcode & 0x80);
+			if (b == 0x00 && _peekByte() == 0x49)
+			{
+				do
+				{
+					b = _getByte();
+				} while (b != 0x00);
+			}
+			break;
+		}
+		// fallthrough
 	case 0xE2: // stopScript
 		_eatByteOrVar(opcode & 0x80);
 		break;


### PR DESCRIPTION
Some versions of MANIAC-V2-EN miss a byte in the opcode sequence for
printEgo, causing a fatal error while trying to export the subtitles.

See #12.

Here's a cleaner attempt… it's still wrong, because when you import the translation again, the game switches to demo mode in ScummVM.