### PR TITLE
fix(scummrp): Fix fatal "Duplicate offset in index" error for MONKEY1-FLOPPY-VGA

### DIFF
--- a/src/ScummRp/block.cpp
+++ b/src/ScummRp/block.cpp
@@ -782,6 +782,18 @@ void RoomPack::_checkDupOffset(byte roomId, int32 offset)
 				ScummRpIO::info(INF_DETAIL, "Removed SC_0051 from index (duplicate of SC_0052)");
 			}
 		}
+		else if (j == 2 && ScummRp::tocs[i]->getType() == TableOfContent::TOCT_COST)
+		{
+			// Hack for Monkey1 Floppy VGA
+			if (roomId == 59 && ScummRp::tocs[i]->getSize() == 199
+				&& (*ScummRp::tocs[i])[10].offset == (*ScummRp::tocs[i])[117].offset
+				&& (*ScummRp::tocs[i])[10].roomId == (*ScummRp::tocs[i])[117].roomId)
+			{
+				(*ScummRp::tocs[i])[117].offset = -1;
+				j = 1;
+				ScummRpIO::info(INF_DETAIL, "Removed CO_0117 from index (duplicate of CO_0010)");
+			}
+		}
 		n += j;
 		if (n > 1)
 			throw RoomPack::BadOffset(xsprintf("Duplicate offset in index: 0x%X in room %i", offset, roomId));


### PR DESCRIPTION
It appears that this version of Monkey Island has `CO_0117` as a duplicate
costume for `CO_0010`.  This would break ScummRp and ScummTr extraction.

As far as I know, the EGA and the CD-ROM versions of Monkey Island 1
don't have this bug.

Issue #18.