### PR TITLE
feat(scummtr): Add some encoding headers to translation files

### DIFF
--- a/src/ScummTr/scummtr.cpp
+++ b/src/ScummTr/scummtr.cpp
@@ -175,6 +175,9 @@ void ScummTr::_processGameFilesV123()
 	{
 		Text text(ScummTr::_paramTextFile, ScummTr::_textOptions, charset);
 
+		if (ScummRp::_options & ScummRp::OPT_EXPORT)
+			text.addExportHeaders();
+
 		for (int i = 1; i < 98; ++i)
 		{
 			std::string dataPath(ScummRp::_paramGameDir);
@@ -229,6 +232,9 @@ void ScummTr::_processGameFilesV4567()
 	ScummRp::_prepareTmpIndex();
 	{
 		Text text(ScummTr::_paramTextFile, ScummTr::_textOptions, charset);
+
+		if (ScummRp::_options & ScummRp::OPT_EXPORT)
+			text.addExportHeaders();
 
 		for (int i = 1; i < numberOfDisks; ++i)
 		{

--- a/src/ScummTr/text.hpp
+++ b/src/ScummTr/text.hpp
@@ -125,10 +125,12 @@ private:
 public:
 	void setInfo(int lflfId, uint32 tag, int id);
 	const char *info() const;
+	const char *internalCommentHeader() const;
 	int32 lineNumber() const;
 	void firstLine();
 	bool nextLine(std::string &s, Text::LineType lineType);
 	void clear();
+	void addExportHeaders();
 	void addLine(std::string s, Text::LineType lineType, int op = -1);
 
 public:


### PR DESCRIPTION
We only support Windows-1252/ISO-8859-1 files, but if you work from
an English game (which is likely), you could just obtain a pure ASCII
file, and then most text editor nowadays would convert that to UTF-8,
which we don't support for the moment.

So, just add some headers when exporting a translation file, with
some explicit ISO-8859-1 characters, so that Microsoft Notepad goes to
"ANSI" mode, and most other text editors will (hopefully) switch to
ISO-8859-1, too.