### PR TITLE
fix: Fix unitialized _LOFFOffset member variable

### DIFF
--- a/src/ScummRp/block.cpp
+++ b/src/ScummRp/block.cpp
@@ -1039,7 +1039,7 @@ void LFLFPack::_subblockUpdated(TreeBlock &subblock, int32 sizeDiff)
  */
 
 LECFPack::LECFPack() :
-    TreeBlock(), _firstBlockOffset(0), _loff()
+    TreeBlock(), _firstBlockOffset(0), _loff(), _LOFFOffset(0)
 {
 }
 
@@ -1048,7 +1048,7 @@ LECFPack::~LECFPack()
 }
 
 LECFPack::LECFPack(const TreeBlock &block) :
-    TreeBlock(block), _firstBlockOffset(0), _loff()
+    TreeBlock(block), _firstBlockOffset(0), _loff(), _LOFFOffset(0)
 {
 	_init();
 }
@@ -1058,6 +1058,7 @@ LECFPack &LECFPack::operator=(const TreeBlock &block)
 	TreeBlock::operator=(block);
 
 	_firstBlockOffset = 0;
+	_LOFFOffset = 0;
 	_init();
 
 	return *this;


### PR DESCRIPTION
[C26495](https://docs.microsoft.com/en-us/cpp/code-quality/c26495) in MSVC reports that the `_LOFFOffset` member variable is left unitialized in `LECFPack::LECFPack()`.

I _think_ that it should also be added to `LECFPack::LECFPack(const TreeBlock &block)` and `&LECFPack::operator=(const TreeBlock &block)`, but I need to make sure that it doesn't cause any regression, because I'm not very at ease with this part of the code.