### PR TITLE
feat(releases): Upgrade the win32 builder from Debian 9 to 10

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -289,6 +289,20 @@ Yes, ScummTR and ScummRP have problems with the “V2” version of Maniac Mansi
 
 The “V1” version of the game appears to be OK, though.
 
+### I see `Bad data was found and ignored` messages, is anything wrong?
+
+This may happen with some games, because of original error in the official game resources, or because of a bug on our side.
+
+For example, the FM-TOWNS of Zak McKracken (as sold by GOG) will output this warning:
+
+```
+WARNING: Bad data was found and ignored at 0x6 in 47.LFL
+```
+
+As long as it's printed as a `WARNING` (and not as an `ERROR`), and as long as the game appears to play fine even after modifying it, then you can probably ignore this.
+
+However, this kind of warnings can also hint at a possible game corruption, or a bug. Please [open an issue](https://github.com/dwatteau/scummtr/issues) if you're stuck.
+
 ### When I extract the text from The Dig, I get English text although my game is not in English
 
 It appears that *The Dig* contains both the original text and its translation, and that ScummTR only deals with the former.

--- a/releases/Dockerfile.win32
+++ b/releases/Dockerfile.win32
@@ -1,8 +1,8 @@
 # Win32 build, with best-effort support for Windows XP (thus, using the
-# older 5.0.1 version of Mingw-w64 on Debian 9 is intentional).  Also
-# uses CMake 3.7.2.
+# older 6.0.0 version of Mingw-w64 on Debian 10 is intentional).  Also
+# uses CMake 3.13.4.
 
-FROM debian:9.13-slim AS scummtr-win32-base
+FROM debian:10-slim AS scummtr-win32-base
 
 RUN apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cmake make mingw-w64 \


### PR DESCRIPTION
Debian 9 support will end in late June 2022, and using Debian 10 lets us do more base layer re-use with the msdos builder.

We could upgrade to Debian 11, but Mingw-w64 recommend using an older Mingw-w64 release when targeting older Windows versions.

Resulting binaries appear to be OK on my Windows XP VM.

To be merged before June 2022, ideally. I'm waiting just in case I need to make a ScummTR 0.5.2 release instead of a 0.6.0 release.