### PR TITLE
feat(ci): Move Ubuntu 22.04 runner to the new arm64 builders

### DIFF
--- a/.github/workflows/build-basic-test.yml
+++ b/.github/workflows/build-basic-test.yml
@@ -25,8 +25,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: 'Ubuntu 22.04 (oldest g++)'
-            os: ubuntu-22.04
+          - name: 'Ubuntu 22.04 (arm64, oldest g++)'
+            os: ubuntu-22.04-arm
             gccver: 9
             extraargs: '-DCMAKE_CXX_COMPILER=g++-9'
           - name: 'Ubuntu 24.04 (newest g++)'

--- a/src/ScummFont/scummfont.cpp
+++ b/src/ScummFont/scummfont.cpp
@@ -26,11 +26,17 @@
  * were never released.
  */
 
-// Some useful references:
+// SCUMM charset format references:
 //
 // https://wiki.scummvm.org/index.php?title=SCUMM/Technical_Reference/Charset_resources
 // https://wiki.scummvm.org/index.php/SCUMM/Technical_Reference/SCUMM_6_resource_files#3.2.20_CHAR
+//
+// BMP format references:
+//
 // https://formats.kaitai.io/bmp/index.html
+// https://freeimage.sourceforge.io/fnet/html/4720264E.htm
+// https://github.com/HexFiend/HexFiend/blob/v2.18.1/templates/Images/BMP.tcl
+// https://github.com/synalysis/Grammars/blob/35e53acbad8d25faefefdf0863d2a08cc71918a8/bitmap.grammar
 
 #include "common/types.hpp"
 #include "common/file.hpp"


### PR DESCRIPTION
Because why not.