### PR TITLE
feat(common): Improve _xorBuffer() performance

### DIFF
--- a/src/common/file.cpp
+++ b/src/common/file.cpp
@@ -28,6 +28,7 @@
 #include "common/io.hpp"
 #include "common/toolbox.hpp"
 
+#include <cstddef>
 #include <cstring>
 
 #include <algorithm>
@@ -783,7 +784,7 @@ void FilePart::_xorBuffer(char *buffer, byte xorKey, std::streamsize n)
 	{
 		// If the buffer isn't already 4-byte aligned, process all the
 		// bytes, before hitting a 4-byte boundary
-		alignBytes = (-(reinterpret_cast<size_t>(buffer))) & (sizeof(uint32) - 1);
+		alignBytes = static_cast<std::streamsize>((-reinterpret_cast<ptrdiff_t>(buffer)) & (sizeof(uint32) - 1));
 		if (alignBytes > 0 && alignBytes <= n)
 		{
 			for ( ; i < alignBytes; ++i)


### PR DESCRIPTION
Thomas' original code had some logic to xor the values with 4 bytes at once, to improve performance.

However, this caused -Wcast-align issues on some platforms (see issue #10 for more details). This code was then removed in commit ecff30b86c022aa60941a8f71f7e7bc26e96f492.

This new approach restores a bit of this logic, but it's now done in a way to avoid unaligned loads. It seems to work on that old mips64el board I have.

**TODO:**

- [ ] do more tests
- [ ] see if it does make a difference, regarding performance (is there a real bottleneck there?)
- [ ] don't forget to test with different compilers: GCC, Clang, MSVC…
- [ ] check everything's still OK on a big-endian environment
- [ ] see if it improves issue #4, in some way